### PR TITLE
Allow users to rerig human with each update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ link_app.sh
 exts/siborg.create.human/data/*
 !exts/siborg.create.human/data/rigs/
 !exts/siborg.create.human/data/*.png
+
+/venv/

--- a/exts/siborg.create.human/siborg/create/human/ext_ui.py
+++ b/exts/siborg.create.human/siborg/create/human/ext_ui.py
@@ -99,7 +99,7 @@ class MHWindow(ui.Window):
                     ui.Button(
                         "Update Meshes in Scene",
                         height=50,
-                        clicked_fn=lambda: mh_usd.add_to_scene(self.mh_call),
+                        clicked_fn=lambda: mh_usd.add_to_scene(self.mh_call, True),
                     )
                     # Apply skeleton
                     ui.Button(

--- a/exts/siborg.create.human/siborg/create/human/ext_ui.py
+++ b/exts/siborg.create.human/siborg/create/human/ext_ui.py
@@ -97,13 +97,7 @@ class MHWindow(ui.Window):
                     )
                     # Updates current human in omniverse scene
                     ui.Button(
-                        "Update Meshes in Scene",
-                        height=50,
-                        clicked_fn=lambda: mh_usd.add_to_scene(self.mh_call, True),
-                    )
-                    # Apply skeleton
-                    ui.Button(
-                        "Bake and Rig",
+                        "Update Human in Scene",
                         height=50,
                         clicked_fn=lambda: mh_usd.add_to_scene(self.mh_call, True),
                     )

--- a/exts/siborg.create.human/siborg/create/human/mh_usd.py
+++ b/exts/siborg.create.human/siborg/create/human/mh_usd.py
@@ -134,28 +134,28 @@ def add_to_scene(mh_call: MHCaller, add_skeleton : bool = False):
         cur_human.joint_names = joint_names
         cur_human.joint_paths = joint_paths
 
-        # Check if there is an existing SkelAnimation under the skeleton
-        skelroot = stage.GetPrimAtPath(cur_human.skel_root_path)
-        skeletons = [x for x in skelroot.GetChildren() if x.GetTypeName() =='Skeleton']
-        # TODO assert that there is only one skeleton
-        if len(skeletons) > 0:
-            skel_children = skeletons[0].GetChildren()
-        else:
-            skel_children = []
+        # # Check if there is an existing SkelAnimation under the skeleton
+        # skelroot = stage.GetPrimAtPath(cur_human.skel_root_path)
+        # skeletons = [x for x in skelroot.GetChildren() if x.GetTypeName() =='Skeleton']
+        # # TODO assert that there is only one skeleton
+        # if len(skeletons) > 0:
+        #     skel_children = skeletons[0].GetChildren()
+        # else:
+        #     skel_children = []
 
-        animations = [x for x in skel_children if x.GetTypeName() =='SkelAnimation']
-        # TODO assert that there is only one animation
-        if len(animations) > 0:
-            animation = UsdSkel.Animation(animations[0])
+        # animations = [x for x in skel_children if x.GetTypeName() =='SkelAnimation']
+        # # TODO assert that there is only one animation
+        # if len(animations) > 0:
+        #     animation = UsdSkel.Animation(animations[0])
             
-            pose_np = np.array(pose_transforms)
-            rest_np = np.array(rest_transforms)
+        #     pose_np = np.array(pose_transforms)
+        #     rest_np = np.array(rest_transforms)
 
-            rest_np[:,0:3,0:3] = pose_np[:,0:3,0:3]
+        #     rest_np[:,0:3,0:3] = pose_np[:,0:3,0:3]
 
-            new_rest = Vt.Matrix4dArray([Gf.Matrix4d(x.tolist()) for x in rest_np])
+        #     new_rest = Vt.Matrix4dArray([Gf.Matrix4d(x.tolist()) for x in rest_np])
 
-            animation.SetTransforms(rest_transforms)
+        #     animation.SetTransforms(rest_transforms)
 
         
 
@@ -373,11 +373,11 @@ def setup_bindings(paths: List[Sdf.Path], stage: Usd.Stage, skeleton: UsdSkel.Sk
             # Create a relationship between the binding and the skeleton
             binding.CreateSkeletonRel().SetTargets([skeleton.GetPath()])
             # Create a skeleton animation
-            anim = UsdSkel.Animation.Define(stage, skeleton.GetPath().AppendChild("Anim"))
-            # Create a relationship between the binding and the skeleton animation
-            binding.CreateSkeletonRel().SetTargets([anim.GetPrim().GetPath()])
+            # anim = UsdSkel.Animation.Define(stage, skeleton.GetPath().AppendChild("Anim"))
+            # # Create a relationship between the binding and the skeleton animation
+            # binding.CreateSkeletonRel().SetTargets([anim.GetPrim().GetPath()])
 
-            anim.GetJointsAttr().Set(joint_tokens)
+            # anim.GetJointsAttr().Set(joint_tokens)
 
 
         # Add the binding to the list to return

--- a/exts/siborg.create.human/siborg/create/human/mh_usd.py
+++ b/exts/siborg.create.human/siborg/create/human/mh_usd.py
@@ -121,26 +121,25 @@ def add_to_scene(mh_call: MHCaller, add_skeleton : bool = False):
         UsdGeom.Xform.Define(stage, rootPath)
 
     if mhskel and add_skeleton:
-        # Only redefine a skeleton if it doesn't exist 
-        if not cur_human.usdSkel:
-            # Create the USD skeleton in our stage using the mhskel data
-            (usdSkel, rootPath, joint_names, joint_paths) = setup_skeleton(rootPath, 
-                                                                            stage, 
-                                                                            mhskel, 
-                                                                            offset
-                                                                           )
+        #TODO update MH stored skeleton pose so that it matches the USD skeleton pose
+        # Create the USD skeleton in our stage using the mhskel data
+        (usdSkel, rootPath, joint_names, joint_paths) = setup_skeleton(rootPath, 
+                                                                        stage, 
+                                                                        mhskel, 
+                                                                        offset
+                                                                        )
 
-            cur_human.usdSkel = usdSkel
-            cur_human.skel_root_path = rootPath
-            cur_human.joint_names = joint_names
-            cur_human.joint_paths = joint_paths
+        cur_human.usdSkel = usdSkel
+        cur_human.skel_root_path = rootPath
+        cur_human.joint_names = joint_names
+        cur_human.joint_paths = joint_paths
 
-            # delete mesh geometry not previously in the skelroot
+        # delete mesh geometry not previously in the skelroot
 
-            for path in cur_human.usd_mesh_paths:
-                prim = stage.GetPrimAtPath(path)
-                if prim.IsValid():
-                    stage.RemovePrim(path)
+        for path in cur_human.usd_mesh_paths:
+            prim = stage.GetPrimAtPath(path)
+            if prim.IsValid():
+                stage.RemovePrim(path)
 
         usd_mesh_paths = setup_meshes(mh_meshes, stage, cur_human.skel_root_path, offset)
 

--- a/exts/siborg.create.human/siborg/create/human/mh_usd.py
+++ b/exts/siborg.create.human/siborg/create/human/mh_usd.py
@@ -170,7 +170,7 @@ def add_to_scene(mh_call: MHCaller, add_skeleton : bool = False):
 
         # Create bindings between meshes and the skeleton. Returns a list of
         # bindings the length of the number of meshes
-        bindings = setup_bindings(usd_mesh_paths, stage, cur_human.usdSkel)
+        bindings = setup_bindings(usd_mesh_paths, stage, cur_human.usdSkel, joint_paths)
 
         # Setup weights for corresponding mh_meshes (which hold the data) and
         # bindings (which link USD_meshes to the skeleton)
@@ -332,7 +332,7 @@ def calculate_influences(mh_mesh: Object3D, joint_names: List[str]):
     return indices, weights
 
 
-def setup_bindings(paths: List[Sdf.Path], stage: Usd.Stage, skeleton: UsdSkel.Skeleton):
+def setup_bindings(paths: List[Sdf.Path], stage: Usd.Stage, skeleton: UsdSkel.Skeleton, joint_tokens):
     """Setup bindings between meshes in the USD scene and the skeleton
 
     Parameters
@@ -372,6 +372,13 @@ def setup_bindings(paths: List[Sdf.Path], stage: Usd.Stage, skeleton: UsdSkel.Sk
             binding = UsdSkel.BindingAPI.Apply(prim)
             # Create a relationship between the binding and the skeleton
             binding.CreateSkeletonRel().SetTargets([skeleton.GetPath()])
+            # Create a skeleton animation
+            anim = UsdSkel.Animation.Define(stage, skeleton.GetPath().AppendChild("Anim"))
+            # Create a relationship between the binding and the skeleton animation
+            binding.CreateSkeletonRel().SetTargets([anim.GetPrim().GetPath()])
+
+            anim.GetJointsAttr().Set(joint_tokens)
+
 
         # Add the binding to the list to return
         bindings.append(binding)

--- a/exts/siborg.create.human/siborg/create/human/mh_usd.py
+++ b/exts/siborg.create.human/siborg/create/human/mh_usd.py
@@ -612,14 +612,14 @@ def setup_skeleton(rootPath: str, stage: Usd.Stage, skeleton: Skeleton, offset: 
     # we can abide by Lina Halper's animation retargeting guidelines:
     # https://docs.omniverse.nvidia.com/prod_extensions/prod_extensions/ext_animation-retargeting.html
     # TODO encapsulate in scope for clarity
-    originalRoot = skeleton.roots[0]
-    newRoot = skeleton.addBone(
-        "RootJoint", None, "newRoot_head", originalRoot.tailJoint
-    )
-    originalRoot.parent = newRoot
-    newRoot.headPos -= offset
-    newRoot.build()
-    newRoot.children.append(originalRoot)
+    # originalRoot = skeleton.roots[0]
+    # newRoot = skeleton.addBone(
+    #     "RootJoint", None, "newRoot_head", originalRoot.tailJoint
+    # )
+    # originalRoot.parent = newRoot
+    # newRoot.headPos -= offset
+    # newRoot.build()
+    # newRoot.children.append(originalRoot)
 
     # Setup a breadth-first search of our skeleton as a tree
     # TODO encapsulate in scope for clarity


### PR DESCRIPTION
Updates to Omniverse mean that users can now refresh the rig every time the human is updated in the scene. The "bake and rig" button has been removed. Rigs no longer debind or cause meshes to explode after targets are adjusted.