### PR TITLE
Handling proxies as prims

### DIFF
--- a/exts/siborg.create.human/siborg/create/human/browser/delegate.py
+++ b/exts/siborg.create.human/siborg/create/human/browser/delegate.py
@@ -5,6 +5,7 @@ import omni.kit.app
 from omni.kit.browser.core import get_legacy_viewport_interface
 from omni.kit.browser.folder.core import FolderDetailDelegate
 from .model import MHAssetBrowserModel, AssetDetailItem
+from ..mhcaller import MHCaller
 
 import asyncio
 from pathlib import Path
@@ -37,6 +38,9 @@ class AssetDetailDelegate(FolderDetailDelegate):
         super().__init__(model=model)
         # Reference to the browser asset model
         self.model = model
+
+        # Reference to the human
+        self._human = model.human
         self._settings = carb.settings.get_settings()
         # The context menu that opens on right_click
         self._context_menu: Optional[ui.Menu] = None
@@ -104,12 +108,12 @@ class AssetDetailDelegate(FolderDetailDelegate):
         return item.url
 
     def on_double_click(self, item: FileDetailItem):
-        """Method to execute when an asset is doubleclicked. Adds an item to
-        to the list widget that shows currently applied assets
+        """Method to execute when an asset is doubleclicked. Adds the asset to the
+        human.
 
         Parameters
         ----------
         item : FileDetailItem
             The item that has been doubleclicked
         """
-        self.model.list_model.add_child(item.url)
+        self._human.add_item(item.url)

--- a/exts/siborg.create.human/siborg/create/human/browser/model.py
+++ b/exts/siborg.create.human/siborg/create/human/browser/model.py
@@ -12,6 +12,7 @@ from omni.kit.browser.folder.core import (
     BrowserFile,
 )
 from siborg.create.human.shared import data_path
+from ..human import Human
 
 
 class AssetDetailItem(FileDetailItem):
@@ -39,15 +40,17 @@ class MHAssetBrowserModel(FolderBrowserModel):
         The widget in which to reflect changes when assets are added to the human
     """
 
-    def __init__(self, list_model: DropListModel, *args, **kwargs):
+    def __init__(self, human: Human, *args, **kwargs):
         """Constructs an instance of MHAssetBrowserModel
 
         Parameters
         ----------
-        list_model : DropListModel
-            The list in which to reflect changes when assets are added
+        human : Human
+            The human to which to add assets
         """
-        self.list_model = list_model
+
+        self.human = human
+
         super().__init__(
             *args,
             show_category_subfolders=True,

--- a/exts/siborg.create.human/siborg/create/human/ext_ui.py
+++ b/exts/siborg.create.human/siborg/create/human/ext_ui.py
@@ -194,7 +194,7 @@ class SliderEntryPanelModel:
         # Subscribe to changes in parameter editing
         self.subscriptions.append(
             param.value.subscribe_end_edit_fn(
-                lambda m: self._sanitize_and_run(param, param.value))
+                lambda m: self._sanitize_and_run(param))
         )
 
     def reset(self):
@@ -203,19 +203,17 @@ class SliderEntryPanelModel:
         for param in self.params:
             param.set_value(param.default)
 
-    def _sanitize_and_run(self, param: Param, float_model: ui.SimpleFloatModel):
-        """Make sure that values are within an acceptable range and then run the
-        assigned function
+    def _sanitize_and_run(self, param: Param):
+        """Make sure that values are within an acceptable range and then add the parameter to the
+        list of changed parameters
 
         Parameters
         ----------
         param : Param
             Parameter object which contains acceptable value bounds and
             references the function to run
-        float_model : ui.SimpleFloatModel
-            Model which stores the value from the widget
         """
-        m = float_model
+        m = param.value
         # Get the value from the slider model
         getval = m.get_value_as_float
         # Set the value to the min or max if it goes under or over respectively
@@ -223,10 +221,12 @@ class SliderEntryPanelModel:
             m.set_value(param.min)
         if getval() > param.max:
             m.set_value(param.max)
-        # Run the function given by the parameter using the value from the widget
-        # param.fn(m.get_value_as_float())
+
         # If instant update is toggled on, add the changes to the stage instantly
         if self.toggle.get_value_as_bool():
+            # Run the function given by the parameter using the value from the widget
+            param.fn(m.get_value_as_float())
+            # Run the instant update function
             self.instant_update()
 
     def destroy(self):

--- a/exts/siborg.create.human/siborg/create/human/ext_ui.py
+++ b/exts/siborg.create.human/siborg/create/human/ext_ui.py
@@ -222,12 +222,24 @@ class SliderEntryPanelModel:
         if getval() > param.max:
             m.set_value(param.max)
 
+        # Add the parameter to the list of changed parameters so we can apply the function later
+        self.changed_params.append(param)
+
         # If instant update is toggled on, add the changes to the stage instantly
         if self.toggle.get_value_as_bool():
             # Run the function given by the parameter using the value from the widget
             param.fn(m.get_value_as_float())
             # Run the instant update function
             self.instant_update()
+
+    def apply_changes(self):
+        """Apply the changes made to the parameters. Runs the function associated with each
+        parameter using the value from the widget
+        """
+        for param in self.changed_params:
+            param.fn(param.value.get_value_as_float())
+        # Clear the list of changed parameters
+        self.changed_params = []
 
     def destroy(self):
         """Destroys the instance of SliderEntryPanelModel. Deletes event
@@ -600,7 +612,7 @@ class ParamPanelModel(ui.AbstractItemModel):
         self.toggle = toggle
 
         # Reference to models for each modifier/parameter. The models store modifier
-        # data for reference in the UI
+        # data for reference in the UI, and track the values of the sliders
         self.models = []
 
 

--- a/exts/siborg.create.human/siborg/create/human/ext_ui.py
+++ b/exts/siborg.create.human/siborg/create/human/ext_ui.py
@@ -825,6 +825,11 @@ class ParamPanel(ui.Frame):
                 if param.full_name in modifiers:
                     param.value.set_value(modifiers[param.full_name])
 
+    def update_models(self):
+        """Update all models"""
+        for model in self.models:
+            model.apply_changes()
+
     def destroy(self):
         """Destroys the ParamPanel instance as well as the models attached to each group of parameters
         """

--- a/exts/siborg.create.human/siborg/create/human/human.py
+++ b/exts/siborg.create.human/siborg/create/human/human.py
@@ -22,6 +22,9 @@ class Human:
         """
 
         self.name = name
+        
+        # Reference to the usd prim for the skelroot representing the human in the stage
+        self.prim = None
 
         # Provide a scale factor (Omniverse provided humans are 10 times larger than makehuman)
         self.scale = 10
@@ -372,8 +375,10 @@ class Human:
         usd_prim : Usd.Prim
             Prim from which to update the human model."""
 
+        self.prim = usd_prim
+
         # Get the data from the prim
-        humandata = usd_prim.GetCustomData()
+        humandata = self.prim.GetCustomData()
 
         # Get the list of modifiers from the prim
         modifiers = humandata.get("Modifiers")
@@ -622,3 +627,23 @@ class Human:
                 # from it and bind it to the corresponding USD mesh in the stage
                 material = create_material(texture, name, root, stage)
                 bind_material(mesh, material, stage)
+
+    def add_item(self, path: str):
+        """Add a new asset to the human. Propagates changes to the Makehuman app
+        and then upates the stage with the new asset. If the asset is a proxy,
+        targets will not be applied. If the asset is a skeleton, targets must
+        be applied.
+
+        Parameters
+        ----------
+        path : str
+            Path to an asset on disk
+        """
+
+        # Check if human has a prim
+        if self.prim:
+            # Add an item through the MakeHuman instance and update the widget view
+            MHCaller.add_item(path)
+            self.update_in_scene(self.prim.GetPath().pathString)
+        else:
+            carb.log_warn("No prim selected")

--- a/exts/siborg.create.human/siborg/create/human/human.py
+++ b/exts/siborg.create.human/siborg/create/human/human.py
@@ -375,15 +375,18 @@ class Human:
         # Get the data from the prim
         humandata = usd_prim.GetCustomData()
 
-        # Get the modifiers from the prim
+        # Get the list of modifiers from the prim
         modifiers = humandata.get("Modifiers")
         for m, v in modifiers.items():
             MHCaller.human.getModifier(m).setValue(v, skipDependencies=False)
 
-        # Get the proxies from the prim
+        # Get the list of proxies from the prim
         proxies = humandata.get("Proxies")
 
-        # Make sure the proxies are not empty
+        # Clear the makehuman proxies
+        MHCaller.clear_proxies()
+
+        # Make sure the proxy list stored in the prim is not empty
         if proxies:
             for type, path in proxies.items():
                 # If the proxy type is not "proxymeshes" or "clothes", add it

--- a/exts/siborg.create.human/siborg/create/human/human.py
+++ b/exts/siborg.create.human/siborg/create/human/human.py
@@ -50,7 +50,10 @@ class Human:
     @property
     def prim_path(self):
         """Path to the human prim"""
-        return self.prim.GetPath().pathString
+        if self.prim:
+            return self.prim.GetPath().pathString
+        else:
+            return None
 
     @property
     def objects(self):

--- a/exts/siborg.create.human/siborg/create/human/human.py
+++ b/exts/siborg.create.human/siborg/create/human/human.py
@@ -41,10 +41,16 @@ class Human:
         # Reset the human in makehuman
         MHCaller.reset_human()
 
+        # Reset the prim
+        self.prim = None
+
         # Reset the skeleton
         self.skeleton = Skeleton(self.scale)
 
-
+    @property
+    def prim_path(self):
+        """Path to the human prim"""
+        return self.prim.GetPath().pathString
 
     @property
     def objects(self):
@@ -82,7 +88,7 @@ class Human:
 
         # Create a prim for the human
         # Prim should be a SkelRoot so we can rig the human with a skeleton later
-        UsdSkel.Root.Define(stage, prim_path)
+        self.prim = UsdSkel.Root.Define(stage, prim_path)
 
         # Write the properties of the human to the prim
         self.write_properties(prim_path, stage)
@@ -118,7 +124,7 @@ class Human:
         # Bind the skin material to the first prim in the list (the human)
         bind_material(mesh_paths[0], skin, stage)
 
-        return prim_path
+        return self.prim
 
     def update_in_scene(self, prim_path: str):
         """Updates the human in the scene. Writes the properties of the human to the
@@ -367,7 +373,7 @@ class Human:
             else:
                 prim.SetCustomDataByKey("Proxies:" + type, p.file)
 
-    def set_prim(self, usd_prim):
+    def set_prim(self, usd_prim : Usd.Prim):
         """Updates the human based on the given prim's attributes
 
         Parameters

--- a/exts/siborg.create.human/siborg/create/human/human.py
+++ b/exts/siborg.create.human/siborg/create/human/human.py
@@ -366,23 +366,28 @@ class Human:
             # the format is "group/modifer:value"
             prim.SetCustomDataByKey("Modifiers:" + m.fullName, m.getValue())
 
+
+        # NOTE We are not currently using proxies in the USD export. Proxy data is stored
+        # in their respective mesh prims, so that deleting proxy prims will also remove the
+        # proxies. The following code is left here for reference.
+
         # Get the proxies of the human in mhcaller
-        proxies = MHCaller.proxies
+        # proxies = MHCaller.proxies
 
-        for p in proxies:
-            # Add the proxy to the prim as custom data by key under "Proxies".
-            # Proxy type should be "proxymeshes" if type cannot be determined from the
-            # proxy.type property.
-            type = p.type if p.type else "proxymeshes"
+        # for p in proxies:
+        #     # Add the proxy to the prim as custom data by key under "Proxies".
+        #     # Proxy type should be "proxymeshes" if type cannot be determined from the
+        #     # proxy.type property.
+        #     type = p.type if p.type else "proxymeshes"
 
-            # Only "proxymeshes" and "clothes" should be subdictionaries of "Proxies"
-            if type == "clothes" or type == "proxymeshes":
-                prim.SetCustomDataByKey("Proxies:" + type + ":" + p.name, p.file)
+        #     # Only "proxymeshes" and "clothes" should be subdictionaries of "Proxies"
+        #     if type == "clothes" or type == "proxymeshes":
+        #         prim.SetCustomDataByKey("Proxies:" + type + ":" + p.name, p.file)
 
-            # Other proxy types should be added as a key to the prim with their
-            # type as the key and the path as the value
-            else:
-                prim.SetCustomDataByKey("Proxies:" + type, p.file)
+        #     # Other proxy types should be added as a key to the prim with their
+        #     # type as the key and the path as the value
+        #     else:
+        #         prim.SetCustomDataByKey("Proxies:" + type, p.file)
 
     def set_prim(self, usd_prim : Usd.Prim):
         """Updates the human based on the given prim's attributes

--- a/exts/siborg.create.human/siborg/create/human/human.py
+++ b/exts/siborg.create.human/siborg/create/human/human.py
@@ -276,9 +276,12 @@ class Human:
 
                 meshGeom = UsdGeom.Mesh(prim)
 
-            # If it doesn't exist, make it. This will run the first time a human is created
+            # If it doesn't exist, make it. This will run the first time a human is created and
+            # whenever a new proxy is added
             else:
                 meshGeom = UsdGeom.Mesh.Define(stage, usd_mesh_path)
+
+                prim = meshGeom.GetPrim()
 
                 # Set vertices. This is a list of tuples for ALL vertices in an unassociated
                 # cloud. Faces are built based on indices of this list.
@@ -310,6 +313,14 @@ class Human:
 
                 meshGeom.CreateNormalsAttr(mesh.getNormals())
                 meshGeom.SetNormalsInterpolation("vertex")
+
+                # If the mesh is a proxy, write the proxy path to the mesh prim
+                if mesh.object.proxy:
+                    p = mesh.object.proxy
+                    type = p.type if p.type else "proxymeshes"
+                    prim.SetCustomDataByKey("Proxy_path:", p.file)
+                    prim.SetCustomDataByKey("Proxy_type:", type)
+                    prim.SetCustomDataByKey("Proxy_name:", p.name)
 
             # Set vertex uvs. UVs are represented as a list of tuples, each of which is a 2D
             # coordinate. UV's are used to map textures to the surface of 3D geometry

--- a/exts/siborg.create.human/siborg/create/human/human.py
+++ b/exts/siborg.create.human/siborg/create/human/human.py
@@ -282,6 +282,20 @@ class Human:
             # If it doesn't exist, make it. This will run the first time a human is created and
             # whenever a new proxy is added
             else:
+                # First determine if the mesh is a proxy
+                p = mesh.object.proxy
+                if p:
+                    #  Determine if the mesh is a clothes proxy or a proxymesh. If not, then
+                    #  an existing proxy of this type already exists, and we must overwrite it
+                    type = p.type if p.type else "proxymeshes"
+                    if not (type == "clothes" or type == "proxymeshes"):
+                        for child in self.prim.GetChildren():
+                            child_type = child.GetCustomDataByKey("Proxy_type")
+                            if child_type == type:
+                                # If the child prim has the same type as the proxy, delete it
+                                omni.kit.commands.execute("DeletePrims", paths=[child.GetPath()])
+                                break
+
                 meshGeom = UsdGeom.Mesh.Define(stage, usd_mesh_path)
 
                 prim = meshGeom.GetPrim()

--- a/exts/siborg.create.human/siborg/create/human/human.py
+++ b/exts/siborg.create.human/siborg/create/human/human.py
@@ -410,24 +410,22 @@ class Human:
         for m, v in modifiers.items():
             MHCaller.human.getModifier(m).setValue(v, skipDependencies=False)
 
-        # Get the list of proxies from the prim
-        proxies = humandata.get("Proxies")
+        # Gather proxies from the prim children
+        proxies = []
+        for child in self.prim.GetChildren():
+            if child.GetTypeName() == "Mesh" and child.GetCustomDataByKey("Proxy_path:"):
+                proxies.append(child)
 
         # Clear the makehuman proxies
         MHCaller.clear_proxies()
 
-        # Make sure the proxy list stored in the prim is not empty
+        # # Make sure the proxy list is not empty
         if proxies:
-            for type, path in proxies.items():
-                # If the proxy type is not "proxymeshes" or "clothes", add it
-                # as a proxy with the type as the type
-                if type != "proxymeshes" and type != "clothes":
-                    MHCaller.add_proxy(path, type)
-                else:
-                    # Add every proxy in the "clothes" or "proxymeshes" subdictionary
-                    # In this case, name is unused
-                    for name, path in proxies[type].items():
-                        MHCaller.add_proxy(path, type)
+            for p in proxies:
+                type = p.GetCustomDataByKey("Proxy_type:")
+                path = p.GetCustomDataByKey("Proxy_path:")
+                # name = p.GetCustomDataByKey("Proxy_name:")
+                MHCaller.add_proxy(path, type)
 
         # Update the human in MHCaller
         MHCaller.human.applyAllTargets()

--- a/exts/siborg.create.human/siborg/create/human/human.py
+++ b/exts/siborg.create.human/siborg/create/human/human.py
@@ -290,7 +290,7 @@ class Human:
                     type = p.type if p.type else "proxymeshes"
                     if not (type == "clothes" or type == "proxymeshes"):
                         for child in self.prim.GetChildren():
-                            child_type = child.GetCustomDataByKey("Proxy_type")
+                            child_type = child.GetCustomDataByKey("Proxy_type:")
                             if child_type == type:
                                 # If the child prim has the same type as the proxy, delete it
                                 omni.kit.commands.execute("DeletePrims", paths=[child.GetPath()])

--- a/exts/siborg.create.human/siborg/create/human/mhcaller.py
+++ b/exts/siborg.create.human/siborg/create/human/mhcaller.py
@@ -279,6 +279,12 @@ class MHCaller:
             # Body proxies (musculature, etc)
             cls.human.setProxy(None)
 
+    @classmethod
+    def clear_proxies(cls):
+        """Removes all proxies from the human"""
+        for pxy in cls.proxies:
+            cls.remove_proxy(pxy)
+
     Skeleton = TypeVar("Skeleton")
 
     @classmethod

--- a/exts/siborg.create.human/siborg/create/human/window.py
+++ b/exts/siborg.create.human/siborg/create/human/window.py
@@ -127,9 +127,6 @@ class MHWindow(ui.Window):
         # Update the human in MHCaller
         self._human.set_prim(prim)
 
-        # Update the human prim path
-        self._human_prim_path = event.payload["prim_path"]
-
         # Update the list of applied proxies stored in the list model
         self.proxy_list.model.update()
         # Update the list of applied modifiers
@@ -142,11 +139,12 @@ class MHWindow(ui.Window):
         self._human.reset()
 
         # Create a new human
-        self._human_prim_path = self._human.add_to_scene()
+        self._human.prim = self._human.add_to_scene()
+
         # Get selection.
         selection = omni.usd.get_context().get_selection()
         # Select the new human.
-        selection.set_selected_prim_paths([self._human_prim_path], True)
+        selection.set_selected_prim_paths([self._human.prim_path], True)
 
     def update_human(self):
         """Updates the current human in the scene"""
@@ -154,7 +152,7 @@ class MHWindow(ui.Window):
         self.param_panel.update_models()
 
         # Update the human in the scene
-        self._human.update_in_scene(self._human_prim_path)
+        self._human.update_in_scene(self._human.prim_path)
 
     def destroy(self):
         """Called when the window is destroyed. Unsuscribes from human selection events"""

--- a/exts/siborg.create.human/siborg/create/human/window.py
+++ b/exts/siborg.create.human/siborg/create/human/window.py
@@ -40,19 +40,17 @@ class MHWindow(ui.Window):
         self.list_model = DropListModel()
         # Holds the state of the parameter list
         self.param_model = ParamPanelModel(self.toggle_model)
+        # Keep track of the human
+        self._human = Human()
+
         # A model to hold browser data
         self.browser_model = MHAssetBrowserModel(
-            self.list_model,
+            self._human,
             filter_file_suffixes=["mhpxy", "mhskel", "mhclo"],
             timeout=carb.settings.get_settings().get(
                 "/exts/siborg.create.human.browser.asset/data/timeout"
             ),
         )
-
-
-        # Keep track of the human and human prim path
-        self._human = Human()
-        self._human_prim_path = ""
 
         # Dock UI wherever the "Content" tab is found (bottom panel by default)
         self.deferred_dock_in(

--- a/exts/siborg.create.human/siborg/create/human/window.py
+++ b/exts/siborg.create.human/siborg/create/human/window.py
@@ -117,8 +117,6 @@ class MHWindow(ui.Window):
         # Update the human in MHCaller
         self._human.set_prim(prim)
 
-        # Update the list of applied proxies stored in the list model
-        self.proxy_list.model.update()
         # Update the list of applied modifiers
         self.param_panel.load_values(prim)
 

--- a/exts/siborg.create.human/siborg/create/human/window.py
+++ b/exts/siborg.create.human/siborg/create/human/window.py
@@ -36,8 +36,6 @@ class MHWindow(ui.Window):
 
         # Holds the state of the realtime toggle
         self.toggle_model = ui.SimpleBoolModel()
-        # Holds the state of the proxy list
-        self.list_model = DropListModel()
         # Holds the state of the parameter list
         self.param_model = ParamPanelModel(self.toggle_model)
         # Keep track of the human
@@ -81,30 +79,22 @@ class MHWindow(ui.Window):
                         # can be triggered when new assets are added
                         self.browser = AssetBrowserFrame(self.browser_model)
                         ui.Spacer(width=spacer_width)
-                with ui.ZStack(width=0):
-                    # Draggable splitter
-                    with ui.Placer(offset_x=self.frame.computed_content_width/4, draggable=True, drag_axis=ui.Axis.X):
-                        ui.Rectangle(width=5, name="splitter")
-                    with ui.HStack():
+                with ui.HStack():
+                    with ui.VStack():
                         self.param_panel = ParamPanel(self.param_model, lambda: self.update_human())
-                        ui.Spacer(width=spacer_width)
-                with ui.VStack():
-                    self.proxy_list = DropList(
-                        "Currently Applied Assets", self.list_model)
-                    with ui.HStack(height=0):
-                        # Toggle whether changes should propagate instantly
-                        ui.Label("Update Instantly")
-                        ui.CheckBox(self.toggle_model)
+                        with ui.HStack(height=0):
+                            # Toggle whether changes should propagate instantly
+                            ui.Label("Update Instantly")
+                            ui.CheckBox(self.toggle_model)
+                with ui.VStack(width = 100):
                     # Creates a new human in scene and resets modifiers and assets
                     ui.Button(
                         "New Human",
-                        height=50,
                         clicked_fn=self.new_human,
                     )
                     # Updates current human in omniverse scene
                     ui.Button(
-                        "Update Selected Human",
-                        height=50,
+                        "Update Human",
                         clicked_fn=lambda: self.update_human(),
                     )
 

--- a/exts/siborg.create.human/siborg/create/human/window.py
+++ b/exts/siborg.create.human/siborg/create/human/window.py
@@ -107,7 +107,7 @@ class MHWindow(ui.Window):
                     ui.Button(
                         "Update Selected Human",
                         height=50,
-                        clicked_fn=lambda: self.update_human,
+                        clicked_fn=lambda: self.update_human(),
                     )
 
     def _on_human_selected(self, event):
@@ -153,7 +153,7 @@ class MHWindow(ui.Window):
     def update_human(self):
         """Updates the current human in the scene"""
         # Apply any changed parameters to the human
-        self.param_panel.apply_changes()
+        self.param_panel.update_models()
 
         # Update the human in the scene
         self._human.update_in_scene(self._human_prim_path)

--- a/exts/siborg.create.human/siborg/create/human/window.py
+++ b/exts/siborg.create.human/siborg/create/human/window.py
@@ -88,7 +88,7 @@ class MHWindow(ui.Window):
                     with ui.Placer(offset_x=self.frame.computed_content_width/4, draggable=True, drag_axis=ui.Axis.X):
                         ui.Rectangle(width=5, name="splitter")
                     with ui.HStack():
-                        self.param_panel = ParamPanel(self.param_model, lambda: self._human.update_in_scene(self._human_prim_path))
+                        self.param_panel = ParamPanel(self.param_model, lambda: self.update_human())
                         ui.Spacer(width=spacer_width)
                 with ui.VStack():
                     self.proxy_list = DropList(
@@ -107,7 +107,7 @@ class MHWindow(ui.Window):
                     ui.Button(
                         "Update Selected Human",
                         height=50,
-                        clicked_fn=lambda: self._human.update_in_scene(self._human_prim_path),
+                        clicked_fn=lambda: self.update_human,
                     )
 
     def _on_human_selected(self, event):
@@ -149,6 +149,14 @@ class MHWindow(ui.Window):
         selection = omni.usd.get_context().get_selection()
         # Select the new human.
         selection.set_selected_prim_paths([self._human_prim_path], True)
+
+    def update_human(self):
+        """Updates the current human in the scene"""
+        # Apply any changed parameters to the human
+        self.param_panel.apply_changes()
+
+        # Update the human in the scene
+        self._human.update_in_scene(self._human_prim_path)
 
     def destroy(self):
         """Called when the window is destroyed. Unsuscribes from human selection events"""


### PR DESCRIPTION
Removes proxy list from UI. Proxy data is stored in mesh prims corresponding to proxies. Deleting a mesh prim means its proxy data is no longer tracked. Much more intuitive.

Proxies which only allow one at a time like types "hair", "eyes", etc) replace existing ones when added. Proxy types "clothes" and "proxymeshes" are unrestricted.