### PR TITLE
Extension now starts with window open

### DIFF
--- a/exts/siborg.create.human/siborg/create/human/extension.py
+++ b/exts/siborg.create.human/siborg/create/human/extension.py
@@ -3,8 +3,10 @@ import omni.ui as ui
 import carb
 import carb.events
 import omni
+from functools import partial
+import asyncio
 
-from .window import MHWindow, WINDOW_TITLE
+from .window import MHWindow, WINDOW_TITLE, MENU_PATH
 
 class MakeHumanExtension(omni.ext.IExt):
     # ext_id is current extension id. It can be used with extension manager to query additional information, like where
@@ -31,25 +33,56 @@ class MakeHumanExtension(omni.ext.IExt):
         # create a model to hold the selected prim path
         self._selected_primpath_model = ui.SimpleStringModel("-")
 
-        # Create a path for menu item to open the window
-        self._menu_path = f"Window/{WINDOW_TITLE}"
+        # # Dock window wherever the "Content" tab is found (bottom panel by default)
+        # self._window.deferred_dock_in("Content", ui.DockPolicy.CURRENT_WINDOW_IS_ACTIVE)
 
-        # create a window for the extension
+        ui.Workspace.set_show_window_fn(WINDOW_TITLE, partial(self.show_window, None))
+
+        # create a menu item to open the window
+        editor_menu = omni.kit.ui.get_editor_menu()
+        if editor_menu:
+            self._menu = editor_menu.add_item(
+                MENU_PATH, self.show_window, toggle=True, value=True
+            )
+        # show the window
+        ui.Workspace.show_window(WINDOW_TITLE)
         print("[siborg.create.human] HumanGeneratorExtension startup")
-        self._window = None
-        self._menu = omni.kit.ui.get_editor_menu().add_item(self._menu_path, self._on_menu_click, True)
 
+    def on_shutdown(self):
+        self._menu = None
+        if self._window:
+            self._window.destroy()
+            self._window = None
 
-    def _on_menu_click(self, menu, toggled):
-        """Handles showing and hiding the window from the 'Windows' menu."""
-        if toggled:
-            if self._window is None:
-                self._window = MHWindow(WINDOW_TITLE, self._menu_path)
-            else:
-                self._window.show()
-        else:
-            if self._window is not None:
-                self._window.hide()
+        # Deregister the function that shows the window from omni.ui
+        ui.Workspace.set_show_window_fn(WINDOW_TITLE, None)
+
+    async def _destroy_window_async(self):
+        # wait one frame, this is due to the one frame defer
+        # in Window::_moveToMainOSWindow()
+        await omni.kit.app.get_app().next_update_async()
+        if self._window:
+            self._window.destroy()
+            self._window = None
+
+    def visibility_changed(self, visible):
+        # Called when window closed by user
+        editor_menu = omni.kit.ui.get_editor_menu()
+        # Update the menu item to reflect the window state
+        if editor_menu:
+            editor_menu.set_value(MENU_PATH, visible)
+        if not visible:
+            # Destroy the window, since we are creating new window
+            # in show_window
+            asyncio.ensure_future(self._destroy_window_async())
+
+    def show_window(self, menu, value):
+        """Handles showing and hiding the window"""
+        if value:
+            self._window = MHWindow(WINDOW_TITLE)
+            self._window.set_visibility_changed_fn(self.visibility_changed)
+        elif self._window:
+            self._window.visible = False
 
     def _on_stage_event(self, event):
         if event.type == int(omni.usd.StageEventType.SELECTION_CHANGED):
@@ -73,13 +106,3 @@ class MakeHumanExtension(omni.ext.IExt):
                 if prim_kind == "SkelRoot" and prim.GetCustomDataByKey("human"):
                     carb.log_warn("Human selected")
                     self._bus.push(self._human_selection_event, payload={"prim_path": path})
-
-    def on_shutdown(self):
-        print("[siborg.create.human] HumanGenerator shutdown")
-        omni.kit.ui.get_editor_menu().remove_item(self._menu)
-        if self._window is not None:
-            self._window.destroy()
-            self._window = None
-        # unsubscribe from stage events
-        self._stage_event_sub = None
-

--- a/exts/siborg.create.human/siborg/create/human/window.py
+++ b/exts/siborg.create.human/siborg/create/human/window.py
@@ -9,6 +9,8 @@ import omni
 import carb
 
 WINDOW_TITLE = "Human Generator"
+MENU_PATH = f"Window/{WINDOW_TITLE}"
+
 class MHWindow(ui.Window):
     """
     Main UI window. Contains all UI widgets. Extends omni.ui.Window.
@@ -22,7 +24,7 @@ class MHWindow(ui.Window):
         A browser for MakeHuman assets, including clothing, hair, and skeleton rigs.
     """
 
-    def __init__(self, title, menu_path):
+    def __init__(self, title):
         """Constructs an instance of MHWindow
         
         Parameters
@@ -32,8 +34,6 @@ class MHWindow(ui.Window):
         """
 
         super().__init__(title)
-
-        self._menu_path = menu_path
 
         # Holds the state of the realtime toggle
         self.toggle_model = ui.SimpleBoolModel()
@@ -51,17 +51,11 @@ class MHWindow(ui.Window):
             ),
         )
 
-        # Dock UI wherever the "Content" tab is found (bottom panel by default)
-        self.deferred_dock_in(
-            "Content", ui.DockPolicy.CURRENT_WINDOW_IS_ACTIVE)
 
         # Subscribe to human selection events on the message bus
         bus = omni.kit.app.get_app().get_message_bus_event_stream()
         selection_event = carb.events.type_from_string("siborg.create.human.human_selected")
         self._selection_sub = bus.create_subscription_to_push_by_type(selection_event, self._on_human_selected)
-
-        # Run when visibility changes
-        self.set_visibility_changed_fn(self._on_visibility_changed)
 
         self.frame.set_build_fn(self._build_ui)
 
@@ -167,17 +161,3 @@ class MHWindow(ui.Window):
         self._selection_sub.unsubscribe()
         self._selection_sub = None
         super().destroy()
-
-    def on_shutdown(self):
-        """Called when the extension is shutting down"""
-        self._win=None
-
-    def _on_visibility_changed(self, visible):
-        omni.kit.ui.get_editor_menu().set_value(self._menu_path, visible)
-
-    def show(self):
-        self.visible = True
-        self.focus()
-        
-    def hide(self):
-        self.visible = False


### PR DESCRIPTION
Fixes #97 by adopting conventions from https://github.com/NVIDIA-Omniverse/kit-extension-sample-ui-window/. Small merge conflict with #70 will need to be resolved.